### PR TITLE
fix: prevent OOM in ComposeMessageForm from infinite re-render loop

### DIFF
--- a/src/chat.tsx
+++ b/src/chat.tsx
@@ -1190,14 +1190,17 @@ export function ComposeMessageForm({
     },
   });
 
-  useEffect(() => {
-    if (!initialText && draftText && values.text !== draftText) {
-      setValue("text", draftText);
-    }
-  }, [draftText, initialText, setValue, values.text]);
+  const draftLoaded = useRef(false);
 
   useEffect(() => {
-    if (values.text !== undefined) {
+    if (!draftLoaded.current && !initialText && draftText) {
+      draftLoaded.current = true;
+      setValue("text", draftText);
+    }
+  }, [draftText, initialText, setValue]);
+
+  useEffect(() => {
+    if (draftLoaded.current && values.text !== undefined) {
       void setDraftText(values.text);
     }
   }, [setDraftText, values.text]);

--- a/src/chat.tsx
+++ b/src/chat.tsx
@@ -1190,19 +1190,25 @@ export function ComposeMessageForm({
     },
   });
 
+  const initialTextRef = useRef(initialText ?? draftText ?? "");
   const draftLoaded = useRef(false);
 
   useEffect(() => {
-    if (!draftLoaded.current && !initialText && draftText) {
+    if (!draftLoaded.current && initialText == null && draftText) {
       draftLoaded.current = true;
       setValue("text", draftText);
     }
   }, [draftText, initialText, setValue]);
 
   useEffect(() => {
-    if (draftLoaded.current && values.text !== undefined) {
-      void setDraftText(values.text);
+    if (values.text === undefined) return;
+
+    if (!draftLoaded.current) {
+      if (values.text === initialTextRef.current) return;
+      draftLoaded.current = true;
     }
+
+    void setDraftText(values.text);
   }, [setDraftText, values.text]);
 
   return (


### PR DESCRIPTION
## Summary
- Fix infinite re-render loop between draft load/save effects in `ComposeMessageForm` that caused OOM crashes
- Use a `useRef` flag (`draftLoaded`) to ensure draft text is loaded only once, preventing the cyclic dependency between `setValue` and `setDraftText`

## Test plan
- [x] Open a chat and compose a new message — verify no memory spike / crash
- [x] Close and reopen the compose form — verify draft text is restored correctly
- [x] Type new text and reopen — verify updated draft persists
