### PR TITLE
fix: parse service from accountID, add LINE and Steam support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,17 +7,17 @@
       "name": "beeper",
       "license": "MIT",
       "dependencies": {
-        "@beeper/desktop-api": "^4.2.3",
-        "@raycast/api": "^1.104.6",
-        "@raycast/utils": "^2.2.2",
-        "fuse.js": "^7.1.0"
+        "@beeper/desktop-api": "4.2.3",
+        "@raycast/api": "^1.104.11",
+        "@raycast/utils": "^2.2.3",
+        "fuse.js": "^7.2.0"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.1.1",
         "@types/node": "22.19.3",
-        "@types/react": "19.2.7",
+        "@types/react": "^19.2.14",
         "eslint": "^9.39.2",
-        "prettier": "^3.7.4",
+        "prettier": "^3.8.1",
         "typescript": "^5.9.3"
       }
     },
@@ -28,9 +28,9 @@
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -156,9 +156,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -172,9 +172,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -204,9 +204,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -220,9 +220,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -236,9 +236,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -252,9 +252,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -268,9 +268,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -284,9 +284,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -300,9 +300,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -316,9 +316,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -332,9 +332,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -348,9 +348,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -364,9 +364,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -380,9 +380,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -396,9 +396,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -412,9 +412,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -428,9 +428,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -1036,9 +1036,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.8.0.tgz",
-      "integrity": "sha512-jteNUQKgJHLHFbbz806aGZqf+RJJ7t4gwF4MYa8fCwCxQ8/klJNWc0MvaJiBebk7Mc+J39mdlsB4XraaCKznFw==",
+      "version": "4.10.5",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.10.5.tgz",
+      "integrity": "sha512-qcdCF7NrdWPfme6Kr34wwljRCXbCVpL1WVxiNy0Ep6vbWKjxAjFQwuhqkoyL0yjI+KdwtLcOCGn5z2yzdijc8w==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -1051,7 +1051,7 @@
         "indent-string": "^4.0.0",
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
-        "minimatch": "^9.0.5",
+        "minimatch": "^10.2.5",
         "semver": "^7.7.3",
         "string-width": "^4.2.3",
         "supports-color": "^8",
@@ -1064,10 +1064,46 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@oclif/plugin-autocomplete": {
-      "version": "3.2.39",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.39.tgz",
-      "integrity": "sha512-OwAZNnSpuDjKyhAwoOJkFWxGswPFKBB4hpNIMsj6PUtbKwGBPmD+2wGGPgTsDioVwLmUELSb2bZ+1dxHfvXmvg==",
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.45.tgz",
+      "integrity": "sha512-ENrUg8rbVCjh40uvi3MC9kGbiUoEf11nyqE59RBzegeeLpRXNo/Zp27L9j1tUmPEqGgfS2/wvHPihNzkpK1FDw==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",
@@ -1080,9 +1116,9 @@
       }
     },
     "node_modules/@oclif/plugin-help": {
-      "version": "6.2.36",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.36.tgz",
-      "integrity": "sha512-NBQIg5hEMhvdbi4mSrdqRGl5XJ0bqTAHq6vDCCCDXUcfVtdk3ZJbSxtRVWyVvo9E28vwqu6MZyHOJylevqcHbA==",
+      "version": "6.2.43",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.43.tgz",
+      "integrity": "sha512-aef92VxQECLFDjI4CpgCL+jDuAsc3jzq5gBTLwNzj60mmrh8eDd7B0ABIgWXphb6gdARSRil+/FPtcdiSSupRA==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4"
@@ -1092,13 +1128,13 @@
       }
     },
     "node_modules/@oclif/plugin-not-found": {
-      "version": "3.2.73",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.73.tgz",
-      "integrity": "sha512-2bQieTGI9XNFe9hKmXQjJmHV5rZw+yn7Rud1+C5uLEo8GaT89KZbiLTJgL35tGILahy/cB6+WAs812wjw7TK6w==",
+      "version": "3.2.80",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.80.tgz",
+      "integrity": "sha512-yTLjWvR1r/Rd/cO2LxHdMCDoL5sQhBYRUcOMCmxZtWVWhx4rAZ8KVUPDVsb+SvjJDV5ADTDBgt1H52fFx7YWqg==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.10.1",
-        "@oclif/core": "^4.8.0",
+        "@oclif/core": "^4.10.5",
         "ansis": "^3.17.0",
         "fast-levenshtein": "^3.0.0"
       },
@@ -1107,18 +1143,18 @@
       }
     },
     "node_modules/@raycast/api": {
-      "version": "1.104.6",
-      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.6.tgz",
-      "integrity": "sha512-W3UnZrfh1EH9mteQQOibeUvniDnVsbRgcfSUgVWFTGuI6mzKLFzoM8mD6n5amYQM51JVvbuJbaqtfMqsTmnQCQ==",
+      "version": "1.104.11",
+      "resolved": "https://registry.npmjs.org/@raycast/api/-/api-1.104.11.tgz",
+      "integrity": "sha512-UaLyWDlgtgyruTVclcJ1RAJjRWKc/ISw+WQAzTHui4qpY3olaaXWrE/dox6/7Cd3mFZtkQ6grhdUiYTBsUUfuw==",
       "license": "MIT",
       "dependencies": {
-        "@oclif/core": "^4.5.4",
-        "@oclif/plugin-autocomplete": "^3.2.35",
-        "@oclif/plugin-help": "^6.2.33",
-        "@oclif/plugin-not-found": "^3.2.68",
+        "@oclif/core": "^4.8.4",
+        "@oclif/plugin-autocomplete": "^3.2.40",
+        "@oclif/plugin-help": "^6.2.37",
+        "@oclif/plugin-not-found": "^3.2.74",
         "@types/node": "22.13.10",
         "@types/react": "19.0.10",
-        "esbuild": "^0.25.10",
+        "esbuild": "^0.27.3",
         "react": "19.0.0"
       },
       "bin": {
@@ -1201,9 +1237,9 @@
       }
     },
     "node_modules/@raycast/utils": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.2.tgz",
-      "integrity": "sha512-tZcyWCHZvz4L/i1CGEnSZkBoK6wwX1pzlTKjcWWugbrQyG0QCMOxjKJfRC/iNkD+hHaqhMWUj4Y0LNo/NknvFw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.3.tgz",
+      "integrity": "sha512-YwqleVl0Wk/FOq+672gtvswuwMqjNqIr+c63FhouTEHc1LJ3zaohLSkW4+UcfBjPU8HySKQm+kJqZW1iOM9fnA==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -1243,9 +1279,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1794,9 +1830,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1806,32 +1842,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2129,18 +2165,18 @@
       }
     },
     "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -2188,12 +2224,16 @@
       "license": "ISC"
     },
     "node_modules/fuse.js": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
-      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/get-package-type": {
@@ -2241,9 +2281,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
-      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2482,6 +2522,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -2634,9 +2675,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "beeper",
       "license": "MIT",
       "dependencies": {
-        "@beeper/desktop-api": "4.2.3",
+        "@beeper/desktop-api": "^4.7.0",
         "@raycast/api": "^1.104.11",
         "@raycast/utils": "^2.2.3",
         "fuse.js": "^7.2.0"
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/@beeper/desktop-api": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@beeper/desktop-api/-/desktop-api-4.2.3.tgz",
-      "integrity": "sha512-b5dKEKK6FzbAWRmh6udLxAt1QB1vEtLcBScWdDnMXdVA/rIkpd67LTJz+7KJDa/RQnzOL2zxcDNAC4b7OZpSZw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@beeper/desktop-api/-/desktop-api-4.7.0.tgz",
+      "integrity": "sha512-XIPwQKhqJwl3/95i/xkZN5i0MRc1asjGMvQ4rlOc8Lp19HIxLP4PI551rWFqF4g0RxUGL/bsU7DOOTSFR4Qx4Q==",
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -82,16 +82,16 @@
   ],
   "dependencies": {
     "@beeper/desktop-api": "4.2.3",
-    "@raycast/api": "^1.104.6",
-    "@raycast/utils": "^2.2.2",
-    "fuse.js": "^7.1.0"
+    "@raycast/api": "^1.104.11",
+    "@raycast/utils": "^2.2.3",
+    "fuse.js": "^7.2.0"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",
     "@types/node": "22.19.3",
-    "@types/react": "19.2.7",
+    "@types/react": "^19.2.14",
     "eslint": "^9.39.2",
-    "prettier": "^3.7.4",
+    "prettier": "^3.8.1",
     "typescript": "^5.9.3"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     }
   ],
   "dependencies": {
-    "@beeper/desktop-api": "4.2.3",
+    "@beeper/desktop-api": "^4.7.0",
     "@raycast/api": "^1.104.11",
     "@raycast/utils": "^2.2.3",
     "fuse.js": "^7.2.0"

--- a/src/api.ts
+++ b/src/api.ts
@@ -99,7 +99,7 @@ export const focusApp = async (
     await getBeeperDesktop().focus(params);
     await closeMainWindow();
     await showHUD("Beeper Desktop focused");
-  } catch (error) {
+  } catch {
     await showHUD("Failed to focus Beeper Desktop");
   }
 };
@@ -288,7 +288,6 @@ export const searchContacts = async (accountID: string, query: string) => {
   })) as { items?: BeeperDesktop.User[] };
   return response?.items && Array.isArray(response.items) ? (response.items as BeeperDesktop.User[]) : [];
 };
-
 
 export const listChats = async (params?: {
   accountIDs?: string[];

--- a/src/api.ts
+++ b/src/api.ts
@@ -289,6 +289,7 @@ export const searchContacts = async (accountID: string, query: string) => {
   return response?.items && Array.isArray(response.items) ? (response.items as BeeperDesktop.User[]) : [];
 };
 
+
 export const listChats = async (params?: {
   accountIDs?: string[];
   cursor?: string | null;

--- a/src/chat.tsx
+++ b/src/chat.tsx
@@ -33,6 +33,8 @@ import {
   getRaycastFocusLink,
   useBeeperDesktop,
 } from "./api";
+import { parseServiceFromAccountID } from "./utils/types";
+import { getServiceDisplayName } from "./utils/service-icons";
 
 type InboxFilter = "all" | "inbox" | "primary" | "low-priority" | "archive";
 type ChatTypeFilter = "any" | "single" | "group";
@@ -117,7 +119,6 @@ const mergeIndexedChats = (base: IndexedChat[], updates: IndexedChat[]) => {
 const summarizeChatForIndex = (chat: BeeperDesktop.Chat): BeeperDesktop.Chat => ({
   id: chat.id,
   accountID: chat.accountID,
-  network: chat.network ?? "",
   participants: {
     hasMore: false,
     items: MAX_PARTICIPANTS_STORED > 0 ? (chat.participants?.items ?? []).slice(0, MAX_PARTICIPANTS_STORED) : [],
@@ -125,7 +126,6 @@ const summarizeChatForIndex = (chat: BeeperDesktop.Chat): BeeperDesktop.Chat => 
   },
   type: chat.type,
   unreadCount: chat.unreadCount ?? 0,
-  description: chat.description ?? undefined,
   isArchived: chat.isArchived ?? false,
   isMuted: chat.isMuted ?? false,
   isPinned: chat.isPinned ?? false,
@@ -289,7 +289,7 @@ class ThreadSearchIndex {
 
 const buildSearchFields = (chat: BeeperDesktop.Chat): ChatSearchFields => {
   const title = normalizeSearchValue(chat.title || "");
-  const network = normalizeSearchValue(chat.network || "");
+  const network = normalizeSearchValue(getServiceDisplayName(parseServiceFromAccountID(chat.accountID)) || "");
   const participants =
     chat.participants?.items
       ?.slice(0, MAX_PARTICIPANTS_INDEXED)
@@ -717,17 +717,20 @@ export function ChatListView({
         key={chat.id}
         icon={chat.type === "group" ? Icon.TwoPeople : Icon.Person}
         title={chat.title || "Unnamed Chat"}
-        subtitle={chat.network}
+        subtitle={getServiceDisplayName(parseServiceFromAccountID(chat.accountID))}
         accessories={accessories}
         detail={
           isShowingDetail ? (
             <List.Item.Detail
-              markdown={`# ${chat.title || "Chat"}\n\n${chat.network}\n\n**Unread:** ${chat.unreadCount}`}
+              markdown={`# ${chat.title || "Chat"}\n\n${getServiceDisplayName(parseServiceFromAccountID(chat.accountID))}\n\n**Unread:** ${chat.unreadCount}`}
               metadata={
                 <List.Item.Detail.Metadata>
                   <List.Item.Detail.Metadata.Label title="Chat ID" text={chat.id} />
                   <List.Item.Detail.Metadata.Label title="Account ID" text={chat.accountID} />
-                  <List.Item.Detail.Metadata.Label title="Network" text={chat.network} />
+                  <List.Item.Detail.Metadata.Label
+                    title="Network"
+                    text={getServiceDisplayName(parseServiceFromAccountID(chat.accountID))}
+                  />
                   <List.Item.Detail.Metadata.Label title="Type" text={chat.type} />
                   <List.Item.Detail.Metadata.Separator />
                   <List.Item.Detail.Metadata.TagList title="Status">
@@ -1336,7 +1339,7 @@ export function ChatDetails({ chat }: { chat: BeeperDesktop.Chat }) {
       isLoading={isLoading}
       markdown={`# ${data?.title || chat.title || "Chat"}\n\n**Chat ID:** ${chat.id}\n**Account ID:** ${
         chat.accountID
-      }\n**Network:** ${chat.network}\n**Type:** ${chat.type}\n**Unread:** ${
+      }\n**Network:** ${getServiceDisplayName(parseServiceFromAccountID(chat.accountID))}\n**Type:** ${chat.type}\n**Unread:** ${
         chat.unreadCount
       }\n**Pinned:** ${chat.isPinned ? "Yes" : "No"}\n**Muted:** ${
         chat.isMuted ? "Yes" : "No"

--- a/src/contacts.tsx
+++ b/src/contacts.tsx
@@ -9,7 +9,11 @@ import { ChatThread } from "./chat";
 import { parseServiceFromAccountID } from "./utils/types";
 import { getServiceDisplayName } from "./utils/service-icons";
 
-const getAccountLabel = (account: { accountID: string; network?: string; user?: { fullName?: string; username?: string; email?: string; phoneNumber?: string } }) => {
+const getAccountLabel = (account: {
+  accountID: string;
+  network?: string;
+  user?: { fullName?: string; username?: string; email?: string; phoneNumber?: string };
+}) => {
   const service = getServiceDisplayName(parseServiceFromAccountID(account.accountID));
   const userName =
     account.user?.fullName ||
@@ -136,11 +140,7 @@ export function ContactsView() {
     >
       <List.Dropdown.Item key="all" value="all" title="All Accounts" />
       {indexedAccounts.map((account) => (
-        <List.Dropdown.Item
-          key={account.filterKey}
-          value={account.filterKey}
-          title={getAccountLabel(account)}
-        />
+        <List.Dropdown.Item key={account.filterKey} value={account.filterKey} title={getAccountLabel(account)} />
       ))}
     </List.Dropdown>
   );

--- a/src/contacts.tsx
+++ b/src/contacts.tsx
@@ -6,6 +6,19 @@ import { join } from "node:path";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createBeeperOAuth, createChat, focusApp, listAccounts, retrieveChat, searchContacts } from "./api";
 import { ChatThread } from "./chat";
+import { parseServiceFromAccountID } from "./utils/types";
+import { getServiceDisplayName } from "./utils/service-icons";
+
+const getAccountLabel = (account: { accountID: string; network?: string; user?: { fullName?: string; username?: string; email?: string; phoneNumber?: string } }) => {
+  const service = getServiceDisplayName(parseServiceFromAccountID(account.accountID));
+  const userName =
+    account.user?.fullName ||
+    account.user?.username ||
+    account.user?.email ||
+    account.user?.phoneNumber ||
+    account.accountID;
+  return `${service} • ${userName}`;
+};
 
 const getBeeperAppPath = () => {
   const candidates = ["/Applications/Beeper Desktop.app", join(homedir(), "Applications", "Beeper Desktop.app")];
@@ -44,15 +57,23 @@ export function ContactsView() {
   const { push } = useNavigation();
   const beeperAppPath = getBeeperAppPath();
 
-  useEffect(() => {
-    if (accountFilter === "all" && accounts.length === 1) {
-      setAccountFilter(accounts[0].accountID);
-    }
-  }, [accountFilter, accounts]);
-
   const shouldSearch = query.trim().length > 0 && accounts.length > 0;
   const accountMap = useMemo(() => new Map(accounts.map((account) => [account.accountID, account])), [accounts]);
+  const indexedAccounts = useMemo(
+    () => accounts.map((account, index) => ({ ...account, filterKey: `${account.accountID}-${index}` })),
+    [accounts],
+  );
+  const filterKeyToAccountID = useMemo(
+    () => new Map(indexedAccounts.map((a) => [a.filterKey, a.accountID])),
+    [indexedAccounts],
+  );
   const accountsKey = useMemo(() => accounts.map((account) => account.accountID).join("|"), [accounts]);
+
+  useEffect(() => {
+    if (accountFilter === "all" && indexedAccounts.length === 1) {
+      setAccountFilter(indexedAccounts[0].filterKey);
+    }
+  }, [accountFilter, indexedAccounts]);
   const lastPartialErrorKey = useRef<string | null>(null);
 
   const {
@@ -66,7 +87,9 @@ export function ContactsView() {
       const term = termInput.trim();
       if (!term) return [];
 
-      if (filter === "all") {
+      const resolvedFilter = filter === "all" ? "all" : (filterKeyToAccountID.get(filter) ?? filter);
+
+      if (resolvedFilter === "all") {
         const results = await Promise.allSettled(
           accounts.map(async (account) => {
             const items = await searchContacts(account.accountID, term);
@@ -97,8 +120,8 @@ export function ContactsView() {
         return sortContacts(fulfilled);
       }
 
-      const items = await searchContacts(filter, term);
-      return sortContacts(items.map((contact) => ({ ...contact, accountID: filter })));
+      const items = await searchContacts(resolvedFilter, term);
+      return sortContacts(items.map((contact) => ({ ...contact, accountID: resolvedFilter })));
     },
     [query, accountFilter, accountsKey],
     { keepPreviousData: true },
@@ -112,17 +135,11 @@ export function ContactsView() {
       isLoading={isLoadingAccounts}
     >
       <List.Dropdown.Item key="all" value="all" title="All Accounts" />
-      {accounts.map((account) => (
+      {indexedAccounts.map((account) => (
         <List.Dropdown.Item
-          key={account.accountID}
-          value={account.accountID}
-          title={`${account.network || "Account"} • ${
-            account.user?.fullName ||
-            account.user?.username ||
-            account.user?.email ||
-            account.user?.phoneNumber ||
-            account.accountID
-          }`}
+          key={account.filterKey}
+          value={account.filterKey}
+          title={getAccountLabel(account)}
         />
       ))}
     </List.Dropdown>
@@ -170,15 +187,7 @@ export function ContactsView() {
         const account = accountMap.get((contact as { accountID?: string }).accountID || "");
         const title = contact.fullName || contact.username || contact.id;
         const subtitle = contact.username && contact.fullName ? contact.username : contact.email || contact.phoneNumber;
-        const accountLabel = account
-          ? `${account.network || "Account"} • ${
-              account.user?.fullName ||
-              account.user?.username ||
-              account.user?.email ||
-              account.user?.phoneNumber ||
-              account.accountID
-            }`
-          : undefined;
+        const accountLabel = account ? getAccountLabel(account) : undefined;
         return (
           <List.Item
             key={`${contact.id}-${(contact as { accountID?: string }).accountID ?? "unknown"}`}

--- a/src/list-accounts.tsx
+++ b/src/list-accounts.tsx
@@ -4,7 +4,7 @@ import { createBeeperOAuth } from "./api";
 import { clearStoredAuthentication, getBeeperClient, checkBeeperConnection } from "./services/beeper-client";
 import { MOCK_ACCOUNTS } from "./utils/mock-data";
 import { getServiceDisplayName, getServiceIcon } from "./utils/service-icons";
-import { BeeperAccount, parseService, parseServiceFromAccountID } from "./utils/types";
+import { BeeperAccount, parseServiceFromAccountID } from "./utils/types";
 
 interface Preferences {
   useMockData?: boolean;
@@ -142,9 +142,7 @@ function AccountListItem({ account, onRefresh }: AccountListItemProps) {
       subtitle={account.username || account.displayName}
       icon={{ source: serviceInfo.icon as Icon, tintColor: serviceInfo.tintColor }}
       accessories={[
-        ...(account.isSelfHosted
-          ? [{ tag: { value: "Self-hosted", color: Color.Purple } }]
-          : []),
+        ...(account.isSelfHosted ? [{ tag: { value: "Self-hosted", color: Color.Purple } }] : []),
         {
           tag: {
             value: account.isConnected ? "Connected" : "Disconnected",

--- a/src/list-accounts.tsx
+++ b/src/list-accounts.tsx
@@ -4,7 +4,7 @@ import { createBeeperOAuth } from "./api";
 import { clearStoredAuthentication, getBeeperClient, checkBeeperConnection } from "./services/beeper-client";
 import { MOCK_ACCOUNTS } from "./utils/mock-data";
 import { getServiceDisplayName, getServiceIcon } from "./utils/service-icons";
-import { BeeperAccount, parseService } from "./utils/types";
+import { BeeperAccount, parseService, parseServiceFromAccountID } from "./utils/types";
 
 interface Preferences {
   useMockData?: boolean;
@@ -31,13 +31,18 @@ function ListAccountsCommand() {
       const client = await getBeeperClient();
       const response = await client.accounts.list();
 
-      const transformedAccounts: BeeperAccount[] = (response || []).map((account) => ({
-        id: account.accountID,
-        service: parseService(account.network),
-        displayName: account.user?.fullName || account.network || "Unknown",
-        isConnected: true,
-        username: account.user?.username,
-      }));
+      const transformedAccounts: BeeperAccount[] = (response || []).map((account, index) => {
+        const service = parseServiceFromAccountID(account.accountID);
+        const isSelfHosted = account.accountID?.startsWith("sh-") ?? false;
+        return {
+          id: account.accountID ? `${account.accountID}-${index}` : `account-${index}`,
+          service,
+          displayName: account.user?.fullName || getServiceDisplayName(service),
+          isConnected: true,
+          username: account.user?.username,
+          isSelfHosted,
+        };
+      });
 
       return transformedAccounts.sort((a, b) =>
         getServiceDisplayName(a.service).localeCompare(getServiceDisplayName(b.service)),
@@ -137,6 +142,9 @@ function AccountListItem({ account, onRefresh }: AccountListItemProps) {
       subtitle={account.username || account.displayName}
       icon={{ source: serviceInfo.icon as Icon, tintColor: serviceInfo.tintColor }}
       accessories={[
+        ...(account.isSelfHosted
+          ? [{ tag: { value: "Self-hosted", color: Color.Purple } }]
+          : []),
         {
           tag: {
             value: account.isConnected ? "Connected" : "Disconnected",

--- a/src/services/openChat.ts
+++ b/src/services/openChat.ts
@@ -1,7 +1,8 @@
 import { closeMainWindow } from "@raycast/api";
 import { getBeeperClient } from "./beeper-client";
 import { rankChatMatches, getSuggestionMessage } from "../utils/contact-matching";
-import { BeeperChat, parseService } from "../utils/types";
+import { BeeperChat, parseService, parseServiceFromAccountID } from "../utils/types";
+import { getServiceDisplayName } from "../utils/service-icons";
 
 interface OpenChatOptions {
   chatId?: string;
@@ -45,7 +46,7 @@ export async function openChat(options: OpenChatOptions): Promise<OpenChatResult
         allMatches.push({
           id: chat.id,
           title: chat.title || "",
-          network: chat.network || "",
+          network: getServiceDisplayName(parseServiceFromAccountID(chat.accountID)),
           accountID: chat.accountID,
           type: chat.type,
           lastActivity: chat.lastActivity,

--- a/src/services/sendMessage.ts
+++ b/src/services/sendMessage.ts
@@ -1,6 +1,7 @@
 import { getBeeperClient } from "./beeper-client";
 import { rankChatMatches, getSuggestionMessage } from "../utils/contact-matching";
-import { parseService, BeeperService } from "../utils/types";
+import { parseService, parseServiceFromAccountID, BeeperService } from "../utils/types";
+import { getServiceDisplayName } from "../utils/service-icons";
 
 interface SendMessageOptions {
   chatId?: string;
@@ -36,7 +37,7 @@ export async function sendMessage(options: SendMessageOptions): Promise<SendMess
         allMatches.push({
           id: chat.id,
           title: chat.title || "",
-          network: chat.network || "",
+          network: getServiceDisplayName(parseServiceFromAccountID(chat.accountID)),
         });
         if (allMatches.length >= 20) break;
       }

--- a/src/tools/list-accounts.ts
+++ b/src/tools/list-accounts.ts
@@ -1,6 +1,6 @@
 import { getPreferenceValues } from "@raycast/api";
 import { getBeeperClient, checkBeeperConnection } from "../services/beeper-client";
-import { parseService } from "../utils/types";
+import { parseServiceFromAccountID } from "../utils/types";
 import { getServiceDisplayName } from "../utils/service-icons";
 import { MOCK_ACCOUNTS } from "../utils/mock-data";
 
@@ -13,7 +13,7 @@ export default async function () {
   if (useMockData) {
     return MOCK_ACCOUNTS.map((account) => ({
       service: getServiceDisplayName(account.service),
-      serviceId: account.service,
+      accountId: account.id,
       displayName: account.displayName,
       username: account.username,
       isConnected: account.isConnected,
@@ -29,13 +29,14 @@ export default async function () {
   const accounts = await client.accounts.list();
 
   return (accounts || []).map((account) => {
-    const service = parseService(account.network);
+    const service = parseServiceFromAccountID(account.accountID);
     return {
       service: getServiceDisplayName(service),
-      serviceId: service,
-      displayName: account.user?.fullName || account.network || "Unknown",
+      accountId: account.accountID,
+      displayName: account.user?.fullName || getServiceDisplayName(service),
       username: account.user?.username,
       isConnected: true,
+      isSelfHosted: account.accountID?.startsWith("sh-") ?? false,
     };
   });
 }

--- a/src/tools/summarize-messages.ts
+++ b/src/tools/summarize-messages.ts
@@ -1,7 +1,7 @@
 import { getPreferenceValues } from "@raycast/api";
 import { getBeeperClient, checkBeeperConnection } from "../services/beeper-client";
 import { getServiceDisplayName } from "../utils/service-icons";
-import { parseService } from "../utils/types";
+import { parseService, parseServiceFromAccountID } from "../utils/types";
 import { rankChatMatches, getSuggestionMessage } from "../utils/contact-matching";
 import { MOCK_CHATS, MOCK_MESSAGES } from "../utils/mock-data";
 
@@ -69,7 +69,7 @@ export default async function (input: Input): Promise<SummarizeMessagesResult> {
     allMatches.push({
       id: chat.id,
       title: chat.title || "",
-      network: chat.network || "",
+      network: getServiceDisplayName(parseServiceFromAccountID(chat.accountID)),
       accountID: chat.accountID,
       type: chat.type,
       lastActivity: chat.lastActivity,

--- a/src/tools/summarize-unread.ts
+++ b/src/tools/summarize-unread.ts
@@ -1,7 +1,7 @@
 import { getPreferenceValues } from "@raycast/api";
 import { getBeeperClient, checkBeeperConnection } from "../services/beeper-client";
 import { getServiceDisplayName } from "../utils/service-icons";
-import { parseService } from "../utils/types";
+import { parseService, parseServiceFromAccountID } from "../utils/types";
 import { rankChatMatches, getSuggestionMessage } from "../utils/contact-matching";
 import { MOCK_CHATS, MOCK_MESSAGES } from "../utils/mock-data";
 
@@ -76,7 +76,7 @@ export default async function (input: Input): Promise<SummarizeResult> {
     allMatches.push({
       id: chat.id,
       title: chat.title || "",
-      network: chat.network || "",
+      network: getServiceDisplayName(parseServiceFromAccountID(chat.accountID)),
       accountID: chat.accountID,
       type: chat.type,
       lastActivity: chat.lastActivity,
@@ -180,7 +180,7 @@ async function getAllUnreadChatsSummary(
     allChats.push({
       id: chat.id,
       title: chat.title || "",
-      network: chat.network || "",
+      network: getServiceDisplayName(parseServiceFromAccountID(chat.accountID)),
       type: chat.type,
       lastActivity: chat.lastActivity,
       unreadCount: chat.unreadCount,

--- a/src/utils/service-icons.ts
+++ b/src/utils/service-icons.ts
@@ -23,6 +23,7 @@ export const serviceIcons: Record<BeeperService, ServiceIconConfig> = {
   sms: { icon: Icon.Message, color: Color.Green, tintColor: Color.Green },
   imessage: { icon: Icon.Message, color: Color.Blue, tintColor: Color.Blue },
   matrix: { icon: Icon.Network, color: Color.Green, tintColor: Color.Green },
+  line: { icon: Icon.Message, color: Color.Green, tintColor: Color.Green },
   unknown: { icon: Icon.QuestionMark, color: Color.SecondaryText },
 };
 
@@ -46,6 +47,7 @@ const serviceDisplayNames: Record<BeeperService, string> = {
   sms: "SMS",
   imessage: "iMessage",
   matrix: "Beeper (Matrix)",
+  line: "LINE",
   unknown: "Unknown",
 };
 

--- a/src/utils/service-icons.ts
+++ b/src/utils/service-icons.ts
@@ -24,6 +24,7 @@ export const serviceIcons: Record<BeeperService, ServiceIconConfig> = {
   imessage: { icon: Icon.Message, color: Color.Blue, tintColor: Color.Blue },
   matrix: { icon: Icon.Network, color: Color.Green, tintColor: Color.Green },
   line: { icon: Icon.Message, color: Color.Green, tintColor: Color.Green },
+  steam: { icon: Icon.Gear, color: Color.Blue, tintColor: Color.Blue },
   unknown: { icon: Icon.QuestionMark, color: Color.SecondaryText },
 };
 
@@ -48,6 +49,7 @@ const serviceDisplayNames: Record<BeeperService, string> = {
   imessage: "iMessage",
   matrix: "Beeper (Matrix)",
   line: "LINE",
+  steam: "Steam",
   unknown: "Unknown",
 };
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -17,6 +17,7 @@ export type BeeperService =
   | "sms"
   | "imessage"
   | "matrix"
+  | "line"
   | "unknown";
 
 /**
@@ -28,6 +29,7 @@ export interface BeeperAccount {
   displayName: string;
   isConnected: boolean;
   username?: string;
+  isSelfHosted?: boolean;
 }
 
 /**
@@ -106,6 +108,7 @@ export function parseService(serviceString: string | undefined): BeeperService {
     matrix: "matrix",
     "beeper (matrix)": "matrix",
     beeper: "matrix",
+    line: "line",
   };
 
   if (serviceMap[normalized]) {
@@ -119,4 +122,20 @@ export function parseService(serviceString: string | undefined): BeeperService {
   }
 
   return "unknown";
+}
+
+/**
+ * Extract service name from an accountID string.
+ * Handles formats like "local-whatsapp_ba_...", "sh-line-m", etc.
+ */
+export function parseServiceFromAccountID(accountID: string): BeeperService {
+  if (!accountID) return "unknown";
+
+  // Strip common prefixes: "local-", "sh-"
+  const stripped = accountID.replace(/^(local-|sh-)/, "");
+  // Take the part before the first underscore (e.g., "whatsapp" from "whatsapp_ba_...")
+  // or before a trailing identifier (e.g., "line" from "line-m")
+  const servicePart = stripped.split(/[_]/)[0];
+
+  return parseService(servicePart);
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -138,9 +138,11 @@ export function parseServiceFromAccountID(accountID: string): BeeperService {
 
   // Strip common prefixes: "local-", "sh-"
   const stripped = accountID.replace(/^(local-|sh-)/, "");
-  // Take the part before the first underscore (e.g., "whatsapp" from "whatsapp_ba_...")
-  // or before a trailing identifier (e.g., "line" from "line-m")
-  const servicePart = stripped.split(/[_]/)[0];
+  // Take the part before the first delimiter (e.g., "whatsapp" from "whatsapp_ba_...",
+  // "slackgo" from "slackgo.T01...", "line" from "line-m")
+  const servicePart = stripped.split(/[_.]/)[0];
+  // Strip "go" bridge suffix (e.g., "discordgo" → "discord", "facebookgo" → "facebook")
+  const cleaned = servicePart.replace(/go$/, "");
 
-  return parseService(servicePart);
+  return parseService(cleaned || servicePart);
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -18,6 +18,7 @@ export type BeeperService =
   | "imessage"
   | "matrix"
   | "line"
+  | "steam"
   | "unknown";
 
 /**
@@ -109,6 +110,7 @@ export function parseService(serviceString: string | undefined): BeeperService {
     "beeper (matrix)": "matrix",
     beeper: "matrix",
     line: "line",
+    steam: "steam",
   };
 
   if (serviceMap[normalized]) {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -131,6 +131,11 @@ export function parseService(serviceString: string | undefined): BeeperService {
 export function parseServiceFromAccountID(accountID: string): BeeperService {
   if (!accountID) return "unknown";
 
+  // Matrix/Beeper accounts: "user:beeper.com", "user:beeper.local", or "hungryserv-*"
+  if (accountID.includes(":beeper.com") || accountID.includes(":beeper.local") || accountID.startsWith("hungryserv")) {
+    return "matrix";
+  }
+
   // Strip common prefixes: "local-", "sh-"
   const stripped = accountID.replace(/^(local-|sh-)/, "");
   // Take the part before the first underscore (e.g., "whatsapp" from "whatsapp_ba_...")


### PR DESCRIPTION
> **Note:** Depends on #10 so I recommend reviewing that first

## Summary
- Bump `@beeper/desktop-api` from 4.2.3 to 4.7.0 (removes `network`/`description` fields from `Chat` type)
- Add `parseServiceFromAccountID()` to derive service type from `accountID` strings instead of the removed `network` field
- Handle go-suffixed bridge names (`discordgo`, `facebookgo`, `instagramgo`, `slackgo`)
- Recognize `hungryserv` and `user:beeper.com` as Matrix accounts
- Add **LINE** as a recognized messaging service with icon and display name
- Add **Steam** as a recognized messaging service with gear icon
- Add `isSelfHosted` field to `BeeperAccount` and show "Self-hosted" tag in Connected Accounts
- Fix duplicate React keys in Contacts dropdown (`indexedAccounts` with `filterKey`)
- Standardize account labels with `getAccountLabel` helper in Contacts
- Fix lint issues (`catch (error)` → `catch` in api.ts)

## Test plan
- [x] Connected Accounts shows correct service names derived from accountIDs
- [x] Self-hosted bridges show "Self-hosted" tag
- [x] LINE accounts display with correct icon and "LINE" label
- [x] Steam accounts display with gear icon and "Steam" label
- [x] Recent Chats shows correct network labels
- [x] Contacts dropdown has no duplicate key warnings
- [x] Search Messages shows correct service info
